### PR TITLE
Add meta handlers and transition hook

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { renderToString } from "react-dom/server";
 
 console.log("🚀 | __dirname", __dirname);
-let envPath = path.join(__dirname, "../env", ".env." + (process.env.PUBLIC_ENV || "local"));
+const envPath = path.join(__dirname, "../env", ".env." + (process.env.PUBLIC_ENV || "local"));
 console.log("🚀 | envPath", envPath);
 dotenv.config({ path: envPath });
 
@@ -15,7 +15,7 @@ export default function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  let markup = renderToString(<RemixServer context={remixContext} url={request.url} />);
+  const markup = renderToString(<RemixServer context={remixContext} url={request.url} />);
 
   responseHeaders.set("Content-Type", "text/html");
 

--- a/app/features/bookmarks/BookmarkForm.tsx
+++ b/app/features/bookmarks/BookmarkForm.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "@remix-run/react";
+import { useNavigate, useTransition } from "@remix-run/react";
 import { useState } from "react";
 import { Button } from "~/ui-toolkit/components/Button/Button";
 import { InputField, TextAreaField } from "~/ui-toolkit/components/forms";
@@ -11,13 +11,16 @@ interface BookmarkFormProps {
 }
 const IMAGE_PLACEHOLDER = "https://via.placeholder.com/450?text=Enter+an+image+url";
 export function BookmarkForm({ initial }: BookmarkFormProps) {
-  let form = useValidatedForm(initial);
-  let navigate = useNavigate();
-  let [image, setImage] = useState(initial?.image || IMAGE_PLACEHOLDER);
+  const form = useValidatedForm(initial);
+  const transition = useTransition();
+  const navigate = useNavigate();
+  const [image, setImage] = useState(initial?.image || IMAGE_PLACEHOLDER);
+  const isProcessing = transition.state === "submitting";
+
   return (
     <div className="grid">
       <form.Form method="post" className="g-col-12 g-col-lg-6">
-        <fieldset>
+        <fieldset disabled={isProcessing}>
           <input name="id" type="hidden" value={initial?.id}></input>
           <InputField
             error={form.errors.title}
@@ -58,7 +61,9 @@ export function BookmarkForm({ initial }: BookmarkFormProps) {
             >
               Cancel
             </button>
-            <Button scale="lg">Save</Button>
+            <Button scale="lg" disabled={isProcessing}>
+              {isProcessing ? "Saving..." : "Save"}
+            </Button>
           </div>
         </fieldset>
       </form.Form>

--- a/app/features/bookmarks/BookmarksLeftNav.tsx
+++ b/app/features/bookmarks/BookmarksLeftNav.tsx
@@ -6,7 +6,7 @@ interface BookmarksLeftNavProps {
 }
 
 export function BookmarksLeftNav({ bookmarks }: BookmarksLeftNavProps) {
-  let { bookmarkId } = useParams();
+  const { bookmarkId } = useParams();
   return (
     <>
       <div className="d-flex justify-content-between align-items-center p-5 pb-3 flex-wrap">

--- a/app/features/layout/AppLayout.tsx
+++ b/app/features/layout/AppLayout.tsx
@@ -1,7 +1,7 @@
 import { Link, useLocation } from "@remix-run/react";
 
 export function AppLayout({ children }) {
-  let { pathname } = useLocation();
+  const { pathname } = useLocation();
   return (
     <div className="d-grid h-100" style={{ gridTemplateRows: "auto 1fr auto" }}>
       <header className="border-bottom d-flex px-4 py-2 justify-content-between align-items-center">
@@ -33,10 +33,18 @@ export function AppLayout({ children }) {
       <footer className="p-4 border-top d-flex justify-content-between align-items-center">
         <div>Remix Enterprise Starter</div>
         <nav className="d-flex gap-4">
-          <a href="https://github.com/DroopyTersen/remix-enterprise-starter" target="_blank" rel="noreferrer">
+          <a
+            href="https://github.com/DroopyTersen/remix-enterprise-starter"
+            target="_blank"
+            rel="noreferrer"
+          >
             Source Code
           </a>
-          <a href="https://getbootstrap.com/docs/5.0/getting-started/introduction/" target="_blank" rel="noreferrer">
+          <a
+            href="https://getbootstrap.com/docs/5.0/getting-started/introduction/"
+            target="_blank"
+            rel="noreferrer"
+          >
             Bootstrap Docs
           </a>
           <a href="https://remix.run/docs/en/v1" target="_blank" rel="noreferrer">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -55,7 +55,7 @@ export default function App() {
 }
 
 const getPublicEnvVars = () => {
-  let publicEnv = Object.entries(process.env).reduce((acc, [key, value]) => {
+  const publicEnv = Object.entries(process.env).reduce((acc, [key, value]) => {
     if (key.startsWith("PUBLIC_")) {
       acc[key] = value;
     }

--- a/app/routes/api/url-metadata.ts
+++ b/app/routes/api/url-metadata.ts
@@ -3,13 +3,13 @@ import { unfurl } from "unfurl.js";
 import type { Metadata } from "unfurl.js/dist/types";
 
 export const loader: LoaderFunction = async ({ request }) => {
-  let targetUrl = new URL(request.url).searchParams.get("url");
+  const targetUrl = new URL(request.url).searchParams.get("url");
   if (!targetUrl) {
     return new Response("Missing url query param", { status: 400 });
   }
 
   try {
-    let result = await unfurl(targetUrl);
+    const result = await unfurl(targetUrl);
     return parseMetadataSummary(result, targetUrl);
   } catch (err) {
     console.error("Unable to unfurl link", err);
@@ -20,7 +20,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 };
 
 const parseMetadataSummary = (result: Metadata, targetUrl: string) => {
-  let url = new URL(targetUrl);
+  const url = new URL(targetUrl);
   return {
     title: result?.title || "",
     description: result?.description || "",

--- a/app/routes/bookmarks.tsx
+++ b/app/routes/bookmarks.tsx
@@ -8,10 +8,10 @@ import { validate } from "~/validation/validate";
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData();
-  let intent = formData.get("intent");
+  const intent = formData.get("intent");
 
   if (intent === "save") {
-    let errors = await validate(formData, bookmarkValidators);
+    const errors = await validate(formData, bookmarkValidators);
     console.error(errors);
     if (Object.values(errors).some((e) => e)) {
       return {

--- a/app/routes/bookmarks/__leftnav.tsx
+++ b/app/routes/bookmarks/__leftnav.tsx
@@ -4,7 +4,7 @@ import { BookmarksLeftNav } from "~/features/bookmarks/BookmarksLeftNav";
 import { useRouteData } from "~/ui-toolkit/hooks/useRouteData";
 
 export default function BookmarksLeftNavLayout() {
-  let bookmarks = (useRouteData((r) => r?.data?.bookmarks) || []) as Bookmark[];
+  const bookmarks = (useRouteData((r) => r?.data?.bookmarks) || []) as Bookmark[];
   return (
     <div className="d-grid h-100" style={{ gridTemplateColumns: "minmax(200px, 400px) 1fr" }}>
       <div className="border-end" style={{ overflowY: "auto" }}>

--- a/app/routes/bookmarks/__leftnav/$bookmarkId.edit.tsx
+++ b/app/routes/bookmarks/__leftnav/$bookmarkId.edit.tsx
@@ -1,4 +1,4 @@
-import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import type { ActionFunction, LoaderFunction, MetaFunction } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { bookmarkService } from "~/features/bookmarks/bookmark.service.server";
@@ -11,6 +11,11 @@ import { validate } from "~/validation/validate";
 interface LoaderData {
   bookmark: Bookmark;
 }
+
+export const meta: MetaFunction = () => ({
+  title: "Remix Enterprise Starter - Edit Bookmark",
+  description: "Let's edit an existing bookmark in the Remix Enterprise Starter App!",
+});
 
 export const loader: LoaderFunction = async ({ params }) => {
   const bookmark = await bookmarkService.get(params.bookmarkId);
@@ -32,7 +37,7 @@ export default function EditBookmarkRoute() {
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData();
-  let [errors, hasErrors] = await validate(formData, bookmarkValidators);
+  const [errors, hasErrors] = await validate(formData, bookmarkValidators);
   if (hasErrors) {
     return {
       errors,

--- a/app/routes/bookmarks/__leftnav/$bookmarkId.tsx
+++ b/app/routes/bookmarks/__leftnav/$bookmarkId.tsx
@@ -1,4 +1,4 @@
-import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import type { ActionFunction, LoaderFunction, MetaFunction } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import { bookmarkService } from "~/features/bookmarks/bookmark.service.server";
@@ -11,13 +11,18 @@ interface LoaderData {
   bookmark: Bookmark;
 }
 
+export const meta: MetaFunction = () => ({
+  title: "Remix Enterprise Starter - View Bookmark",
+  description: "Let's view details of a bookmark in the Remix Enterprise Starter App!",
+});
+
 export const loader: LoaderFunction = async ({ params }) => {
   const bookmark = await bookmarkService.get(params.bookmarkId);
   return { bookmark } as LoaderData;
 };
 
 export default function BookmarkDetailsRoute() {
-  let { bookmark } = useLoaderData() as LoaderData;
+  const { bookmark } = useLoaderData() as LoaderData;
 
   return (
     <Card

--- a/app/routes/bookmarks/__leftnav/new.tsx
+++ b/app/routes/bookmarks/__leftnav/new.tsx
@@ -1,10 +1,15 @@
-import type { ActionFunction } from "@remix-run/node";
+import type { ActionFunction, MetaFunction } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import { bookmarkService } from "~/features/bookmarks/bookmark.service.server";
 import { bookmarkValidators } from "~/features/bookmarks/bookmark.validators";
 import { BookmarkForm } from "~/features/bookmarks/BookmarkForm";
 import { AppErrorBoundary } from "~/features/layout/AppErrorBoundary";
 import { validate } from "~/validation/validate";
+
+export const meta: MetaFunction = () => ({
+  title: "Remix Enterprise Starter - Add Bookmark",
+  description: "Let's add a new bookmark to the Remix Enterprise Starter App!",
+});
 
 export default function NewBookmarkRoute() {
   return (
@@ -17,7 +22,7 @@ export default function NewBookmarkRoute() {
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData();
-  let [errors, hasErrors] = await validate(formData, bookmarkValidators);
+  const [errors, hasErrors] = await validate(formData, bookmarkValidators);
   if (hasErrors) {
     return {
       errors,

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -1,3 +1,4 @@
+import type { MetaFunction } from "@remix-run/node";
 import { Link } from "@remix-run/react";
 import type { Bookmark } from "~/features/bookmarks/bookmark.types";
 import { BookmarkCard } from "~/features/bookmarks/BookmarkCard";
@@ -8,9 +9,18 @@ import { useFilteredItemsByText } from "~/ui-toolkit/hooks/useFilteredItems";
 import { useRouteData } from "~/ui-toolkit/hooks/useRouteData";
 
 const FILTER_KEYS = ["title", "url", "description"];
+
+export const meta: MetaFunction = () => ({
+  title: "Remix Enterprise Starter - Bookmarks",
+  description: "List of all of the bookmarks in the Remix Enterprise Starter App!",
+});
+
 export default function BookmarksIndexRoute() {
-  let bookmarks = (useRouteData((r) => r?.data?.bookmarks) || []) as Bookmark[];
-  let { filterText, setFilterText, filteredItems } = useFilteredItemsByText(bookmarks, FILTER_KEYS);
+  const bookmarks = (useRouteData((r) => r?.data?.bookmarks) || []) as Bookmark[];
+  const { filterText, setFilterText, filteredItems } = useFilteredItemsByText(
+    bookmarks,
+    FILTER_KEYS
+  );
 
   if (!bookmarks.length) {
     return (

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,9 +1,15 @@
+import type { MetaFunction } from "@remix-run/node";
 import { AppErrorBoundary } from "~/features/layout/AppErrorBoundary";
 import { Button } from "~/ui-toolkit/components/Button/Button";
 import { useConfigEntry } from "~/ui-toolkit/hooks/useConfig";
 
+export const meta: MetaFunction = () => ({
+  title: "Remix Enterprise Starter - Welcome",
+  description: "Welcome to the Remix Enterprise Starter App!",
+});
+
 export default function Index() {
-  let envSpecficMessage = useConfigEntry(
+  const envSpecficMessage = useConfigEntry(
     "PUBLIC_MESSAGE",
     "Uh oh. Couldn't pull in the message from env variables."
   );


### PR DESCRIPTION
I had a few minutes, and decided to quickly knock some things out to _start_:

- `useTransitionHook` - simple hook to take take the necessary args to send back a status that can be used by forms (not complete, will probably circle back before I merge this).
- Add `meta` handlers to each of our routes
- I could no longer handle the use of `let` for instances when they should be `const` 😂