### PR TITLE
better "no js" handling

### DIFF
--- a/app/features/bookmarks/BookmarkCard.tsx
+++ b/app/features/bookmarks/BookmarkCard.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useTransition } from "@remix-run/react";
+import { Link, useTransition } from "@remix-run/react";
 import { FormButton } from "~/ui-toolkit/components/Button/FormButton";
 import Card from "~/ui-toolkit/components/Card/Card";
 import type { Bookmark } from "./bookmark.types";
@@ -8,7 +8,6 @@ interface BookmarkCardProps {
 }
 
 export function BookmarkCard({ bookmark }: BookmarkCardProps) {
-  const navigate = useNavigate();
   const transition = useTransition();
   const isProcessing = !!transition.submission;
 
@@ -26,15 +25,13 @@ export function BookmarkCard({ bookmark }: BookmarkCardProps) {
         >
           {isProcessing ? "Deleting..." : "Delete"}
         </FormButton>
-        <button
-          type="button"
+        <Link
           className="btn btn-secondary"
           style={{ width: "100px" }}
-          disabled={isProcessing}
-          onClick={() => navigate(`/bookmarks/${bookmark.id}/edit`)}
+          to={`/bookmarks/${bookmark.id}/edit`}
         >
           Edit
-        </button>
+        </Link>
       </div>
     </Card>
   );

--- a/app/features/bookmarks/BookmarkForm.tsx
+++ b/app/features/bookmarks/BookmarkForm.tsx
@@ -27,7 +27,6 @@ export function BookmarkForm({ initial }: BookmarkFormProps) {
             required
             label="Title"
             {...form.register("title", { ...bookmarkValidators.title })}
-            defaultValue={initial?.title || ""}
           />
           <TextAreaField
             error={form.errors.url}
@@ -35,13 +34,12 @@ export function BookmarkForm({ initial }: BookmarkFormProps) {
             name="url"
             {...form.register("url", { ...bookmarkValidators.url })}
             required
-            defaultValue={initial?.url || ""}
           />
           <TextAreaField
             label="Description"
             name="description"
             rows={4}
-            defaultValue={initial?.description || ""}
+            {...form.register("description", { ...bookmarkValidators.description })}
           />
           <TextAreaField
             rows={2}
@@ -50,7 +48,7 @@ export function BookmarkForm({ initial }: BookmarkFormProps) {
             }}
             label="Image"
             name="image"
-            defaultValue={initial?.image || ""}
+            {...form.register("image", { ...bookmarkValidators.image })}
           />
           <div className="d-flex justify-content-end gap-4">
             <button

--- a/app/features/bookmarks/BookmarkForm.tsx
+++ b/app/features/bookmarks/BookmarkForm.tsx
@@ -31,13 +31,11 @@ export function BookmarkForm({ initial }: BookmarkFormProps) {
           <TextAreaField
             error={form.errors.url}
             label="URL"
-            name="url"
             {...form.register("url", { ...bookmarkValidators.url })}
             required
           />
           <TextAreaField
             label="Description"
-            name="description"
             rows={4}
             {...form.register("description", { ...bookmarkValidators.description })}
           />
@@ -47,7 +45,6 @@ export function BookmarkForm({ initial }: BookmarkFormProps) {
               setImage(e.target.value);
             }}
             label="Image"
-            name="image"
             {...form.register("image", { ...bookmarkValidators.image })}
           />
           <div className="d-flex justify-content-end gap-4">

--- a/app/features/bookmarks/bookmark.utils.ts
+++ b/app/features/bookmarks/bookmark.utils.ts
@@ -1,0 +1,8 @@
+import { filterItems } from "~/ui-toolkit/hooks/useFilteredItems";
+import { Bookmark } from "./bookmark.types";
+
+export const FILTER_KEYS = ["title", "url", "description"];
+
+export const filterBookmarks = (bookmarks: Bookmark[], filterText: string) => {
+  return filterItems(bookmarks, filterText, FILTER_KEYS);
+};

--- a/app/routes/__auth/login.tsx
+++ b/app/routes/__auth/login.tsx
@@ -64,7 +64,7 @@ export default function LoginRoute() {
 export const action = async ({ request }) => {
   const formData = await request.formData();
   const errors = await validate(formData, loginValidators);
-  if (errors) return { errors };
+  if (errors) return { errors, formData: Object.fromEntries(formData) };
 
   let returnTo = formData.get("returnTo") || "/";
 

--- a/app/routes/bookmarks.tsx
+++ b/app/routes/bookmarks.tsx
@@ -2,13 +2,19 @@ import type { LoaderFunction } from "@remix-run/node";
 import { Outlet } from "@remix-run/react";
 import { requireAuthenticatedLoader } from "~/features/auth/auth.remixUtils.server";
 import { createBookmarkService } from "~/features/bookmarks/bookmark.service.server";
+import { filterBookmarks } from "~/features/bookmarks/bookmark.utils";
 import { AppErrorBoundary } from "~/features/layout/AppErrorBoundary";
 
 export const loader: LoaderFunction = async ({ request }) => {
   let { access_token } = await requireAuthenticatedLoader(request);
+  let url = new URL(request.url);
   let bookmarkService = createBookmarkService(access_token);
-  const bookmarks = await bookmarkService.getAll();
-  return { bookmarks };
+  let filterText = url.searchParams.get("filter") || "";
+  let bookmarks = await bookmarkService.getAll();
+  if (filterText) {
+    bookmarks = filterBookmarks(bookmarks, filterText);
+  }
+  return { bookmarks, filter: filterText };
 };
 
 export default function BookmarksLayout() {

--- a/app/routes/bookmarks/__leftnav/$bookmarkId.edit.tsx
+++ b/app/routes/bookmarks/__leftnav/$bookmarkId.edit.tsx
@@ -45,7 +45,7 @@ export const action: ActionFunction = async ({ request, params }) => {
   const { formData, access_token } = await requireAuthenticatedAction(request);
   const bookmarkService = createBookmarkService(access_token);
   const errors = await validate(formData, bookmarkValidators);
-  if (errors) return { errors };
+  if (errors) return { errors, formData: Object.fromEntries(formData) };
 
   await bookmarkService.save(Object.fromEntries(formData) as any);
 

--- a/app/routes/bookmarks/__leftnav/$bookmarkId.tsx
+++ b/app/routes/bookmarks/__leftnav/$bookmarkId.tsx
@@ -1,6 +1,6 @@
 import type { ActionFunction, LoaderFunction, MetaFunction } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
-import { useLoaderData, useNavigate, useTransition } from "@remix-run/react";
+import { Link, useLoaderData, useTransition } from "@remix-run/react";
 import {
   requireAuthenticatedAction,
   requireAuthenticatedLoader,
@@ -29,7 +29,6 @@ export const loader: LoaderFunction = async ({ request, params }) => {
 
 export default function BookmarkDetailsRoute() {
   const { bookmark } = useLoaderData() as LoaderData;
-  const navigate = useNavigate();
   const transition = useTransition();
   const isProcessing = !!transition.submission;
 
@@ -51,15 +50,13 @@ export default function BookmarkDetailsRoute() {
         >
           {isProcessing ? "Deleting..." : "Delete"}
         </FormButton>
-        <button
-          type="button"
+        <Link
           className="btn btn-secondary"
           style={{ width: "100px" }}
-          disabled={isProcessing}
-          onClick={() => navigate("edit")}
+          to={`/bookmarks/${bookmark.id}/edit`}
         >
           Edit
-        </button>
+        </Link>
       </div>
     </Card>
   );

--- a/app/routes/bookmarks/__leftnav/new.tsx
+++ b/app/routes/bookmarks/__leftnav/new.tsx
@@ -26,7 +26,7 @@ export const action: ActionFunction = async ({ request }) => {
   let bookmarkService = createBookmarkService(access_token);
 
   let errors = await validate(formData, bookmarkValidators);
-  if (errors) return { errors };
+  if (errors) return { errors, formData: Object.fromEntries(formData) };
 
   const bookmark = await bookmarkService.save(Object.fromEntries(formData) as any);
   return redirect(`/bookmarks/${bookmark.id}`);

--- a/app/routes/bookmarks/index.tsx
+++ b/app/routes/bookmarks/index.tsx
@@ -1,14 +1,13 @@
 import type { MetaFunction } from "@remix-run/node";
 import { Link } from "@remix-run/react";
 import type { Bookmark } from "~/features/bookmarks/bookmark.types";
+import { FILTER_KEYS } from "~/features/bookmarks/bookmark.utils";
 import { BookmarkCard } from "~/features/bookmarks/BookmarkCard";
 import Card from "~/ui-toolkit/components/Card/Card";
 import { Input } from "~/ui-toolkit/components/forms";
 import { Grid } from "~/ui-toolkit/components/Grid/Grid";
 import { useFilteredItemsByText } from "~/ui-toolkit/hooks/useFilteredItems";
 import { useRouteData } from "~/ui-toolkit/hooks/useRouteData";
-
-const FILTER_KEYS = ["title", "url", "description"];
 
 export const meta: MetaFunction = () => ({
   title: "Remix Enterprise Starter - Bookmarks",
@@ -17,9 +16,11 @@ export const meta: MetaFunction = () => ({
 
 export default function BookmarksIndexRoute() {
   const bookmarks = (useRouteData((r) => r?.data?.bookmarks) || []) as Bookmark[];
+  let initialFiterText = useRouteData((r) => r?.data?.filter) as string;
   const { filterText, setFilterText, filteredItems } = useFilteredItemsByText(
     bookmarks,
-    FILTER_KEYS
+    FILTER_KEYS,
+    initialFiterText
   );
 
   if (!bookmarks.length) {
@@ -43,13 +44,17 @@ export default function BookmarksIndexRoute() {
           </Link>
         </div>
         <div style={{ flexGrow: "1", maxWidth: "500px" }}>
-          <Input
-            placeholder="Search bookmarks..."
-            type="search"
-            className="rounded-pill"
-            value={filterText}
-            onChange={(e) => setFilterText(e.currentTarget.value)}
-          />
+          <form onSubmit={(e) => e.preventDefault()} method="GET">
+            <Input
+              autoFocus
+              placeholder="Search bookmarks..."
+              type="search"
+              name="filter"
+              className="rounded-pill"
+              value={filterText}
+              onChange={(e) => setFilterText(e.currentTarget.value)}
+            />
+          </form>
         </div>
       </div>
       <Grid width="400px" gap="2rem">

--- a/app/ui-toolkit/hooks/useFilteredItems.ts
+++ b/app/ui-toolkit/hooks/useFilteredItems.ts
@@ -8,18 +8,7 @@ export const useFilteredItemsByText = (allItems, properties, initialFilterText =
   const debouncedFilterText = useDebouncedValue(filterText, 250);
 
   const filteredItems = useMemo(() => {
-    if (allItems && allItems.length) {
-      if (!properties.length || !debouncedFilterText) {
-        return allItems;
-      }
-      const items = matchSorter(allItems, debouncedFilterText, {
-        keys: properties,
-        threshold: matchSorter.rankings.CONTAINS,
-      });
-      return items;
-    }
-
-    return [];
+    return filterItems(allItems, debouncedFilterText, properties);
   }, [allItems, debouncedFilterText, properties]);
 
   return {
@@ -27,4 +16,19 @@ export const useFilteredItemsByText = (allItems, properties, initialFilterText =
     setFilterText,
     filterText,
   };
+};
+
+export const filterItems = (allItems: any[], filterText: string, filterKeys: string[]) => {
+  if (allItems && allItems.length) {
+    if (!filterKeys.length || !filterText) {
+      return allItems;
+    }
+    const items = matchSorter(allItems, filterText, {
+      keys: filterKeys,
+      threshold: matchSorter.rankings.CONTAINS,
+    });
+    return items;
+  }
+
+  return [];
 };

--- a/app/validation/useValidatedForm.tsx
+++ b/app/validation/useValidatedForm.tsx
@@ -3,6 +3,7 @@ import { Form, useActionData, useSubmit } from "@remix-run/react";
 import { forwardRef, useState } from "react";
 import type { FieldError, UseFormReturn } from "react-hook-form";
 import { useForm } from "react-hook-form";
+import type { ValidationErrors } from "./validation.types";
 
 function createForm(form: UseFormReturn, submit: SubmitFunction) {
   let SnapshottedForm = forwardRef<HTMLFormElement, FormProps>((props, ref) => {
@@ -32,17 +33,37 @@ export function useValidatedForm<TFormValues = any>(
   initial?: TFormValues
 ): UseValidateFormReturn<TFormValues> {
   let submit = useSubmit();
-  let serverErrors = useActionData()?.errors || {};
-  let form = useForm({
-    defaultValues: initial || {},
+  let actionData = useActionData();
+  console.log("🚀 | actionData", actionData);
+  let erroredFormData = actionData?.formData as TFormValues;
+  console.log("🚀 | erroredFormData", erroredFormData);
+  let serverErrors = (actionData?.errors || {}) as ValidationErrors<TFormValues>;
+  let defaultValues = {
+    ...initial,
+    ...(erroredFormData as any),
+  };
+  let form = useForm<TFormValues>({
+    defaultValues,
   });
-  let [Form] = useState(() => createForm(form, submit));
+  let [Form] = useState(() => {
+    return createForm(form as any, submit);
+  });
   let errors = {
     ...form?.formState?.errors,
     ...serverErrors,
   };
+
+  const register = (field, ...rest) => {
+    let props: any = form.register(field, ...rest);
+    if (defaultValues[field]) {
+      props.defaultValue = defaultValues[field];
+    }
+    return props;
+  };
+
   return {
     ...form,
+    register,
     errors,
     Form,
   } as any;

--- a/app/validation/useValidatedForm.tsx
+++ b/app/validation/useValidatedForm.tsx
@@ -33,15 +33,16 @@ export function useValidatedForm<TFormValues = any>(
   initial?: TFormValues
 ): UseValidateFormReturn<TFormValues> {
   let submit = useSubmit();
+  // Pull any errors or previously submitted data from ActionData
   let actionData = useActionData();
-  console.log("🚀 | actionData", actionData);
   let erroredFormData = actionData?.formData as TFormValues;
-  console.log("🚀 | erroredFormData", erroredFormData);
   let serverErrors = (actionData?.errors || {}) as ValidationErrors<TFormValues>;
+
   let defaultValues = {
     ...initial,
     ...(erroredFormData as any),
   };
+
   let form = useForm<TFormValues>({
     defaultValues,
   });
@@ -53,6 +54,7 @@ export function useValidatedForm<TFormValues = any>(
     ...serverErrors,
   };
 
+  // Add `defaultValue` to the list of props the form.register returns
   const register = (field, ...rest) => {
     let props: any = form.register(field, ...rest);
     if (defaultValues[field]) {

--- a/app/validation/validate.ts
+++ b/app/validation/validate.ts
@@ -1,6 +1,11 @@
-import type { FieldError, FieldValues } from "react-hook-form";
+import type { FieldValues } from "react-hook-form";
 import { coreValidators } from "./coreValidators";
-import type { CoreValidator, FormValidators, ValidationRules } from "./validation.types";
+import type {
+  CoreValidator,
+  FormValidators,
+  ValidationErrors,
+  ValidationRules,
+} from "./validation.types";
 
 /**
  * Validates a form and returns an error object with
@@ -9,19 +14,17 @@ import type { CoreValidator, FormValidators, ValidationRules } from "./validatio
 export const validate = async <TFieldValues = FieldValues>(
   formData: FormData,
   validators: FormValidators<TFieldValues>
-) => {
+): Promise<ValidationErrors<TFieldValues>> => {
   let fieldErrors = await Promise.all(
     (Object.keys(validators) as Array<keyof typeof validators>).map(async (field) => {
       return validateField(formData, field, validators[field]);
     })
   );
 
-  let errors: {
-    [key in keyof FormValidators<TFieldValues>]: FieldError;
-  } = fieldErrors.reduce((acc, fieldError) => {
+  let errors: ValidationErrors<TFieldValues> = fieldErrors.reduce((acc, fieldError) => {
     acc[fieldError.field as keyof FormValidators<TFieldValues>] = fieldError.error;
     return acc;
-  }, {} as { [key in keyof typeof validators]: FieldError });
+  }, {} as ValidationErrors<TFieldValues>);
 
   let hasErrors = fieldErrors.some((fieldError) => fieldError.error);
   return hasErrors ? errors : null;

--- a/app/validation/validation.types.ts
+++ b/app/validation/validation.types.ts
@@ -22,3 +22,7 @@ export type CoreValidator = (
 export type CoreValidators = {
   [key in keyof ValidationRules]: CoreValidator;
 };
+
+export type ValidationErrors<TFieldValues = FieldValues> = {
+  [key in keyof FormValidators<TFieldValues>]: FieldError;
+};


### PR DESCRIPTION
The entire app should function with javascript turned off (or if the `<Scripts/>` component was removed from `root.tsx`)

- Handled an issue where the form was getting reset on errored actions. 
- Had into pass back submitted values as part of action data then use it in `defaultValue
- This was abstracted away to auto set defaultValues as part of useValidatedForm
- Updated search filter to support no js (form submission with query param)
- Turned the Edit buttons into links so they work without an `onClick`. If we REALLY needed `<button>` elements I think the play would be to wrap each one in a `Form` so that when you click you submit the form (where `method` is still `GET`).